### PR TITLE
Fix inconsistency in multilang links(made it same as previous repo)

### DIFF
--- a/README-ID.md
+++ b/README-ID.md
@@ -1,5 +1,7 @@
 # KawaiiLogos
 
+[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md)
+
 Hai semuanya. Repositori ini adalah tempat di mana logo-logo yang dibuat oleh Sawaratsuki diunggah.
 
 > [!WARNING]

--- a/README-ID.md
+++ b/README-ID.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md)
+[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Türkçe README](/README-tr.md)
 
 Hai semuanya. Repositori ini adalah tempat di mana logo-logo yang dibuat oleh Sawaratsuki diunggah.
 

--- a/README-tr.md
+++ b/README-tr.md
@@ -1,5 +1,7 @@
 # KawaiiLogolar
 
+[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
+
 Merhaba ve iyi akşamlar. Bu depo, Sawaratsuki tarafından oluşturulan logoların yüklendiği yerdir.
 
 ## Diller

--- a/README-zhHans.md
+++ b/README-zhHans.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [English README](/README_EN.md) | [Indonesian README](/README-ID.md)
+[日本語 README](./README.md) | [English README](/README_EN.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md)
 
 大家好！这个仓库是用于上传由 Sawaratsuki 创建的 Logo 的仓库。
 

--- a/README-zhHans.md
+++ b/README-zhHans.md
@@ -1,5 +1,7 @@
 # KawaiiLogos
 
+[日本語 README](./README.md) | [English README](/README_EN.md) | [Indonesian README](/README-ID.md)
+
 大家好！这个仓库是用于上传由 Sawaratsuki 创建的 Logo 的仓库。
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
+[English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md)
 
 こんにちは、こんばんは。このリポジトリはさわらつきが作成したロゴがアップロードされているリポジトリです。
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[English README](./README_EN.md)|[简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
+[English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
 
 こんにちは、こんばんは。このリポジトリはさわらつきが作成したロゴがアップロードされているリポジトリです。
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # KawaiiLogos
 
-[简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
+[English README](./README_EN.md)|[简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
 
 こんにちは、こんばんは。このリポジトリはさわらつきが作成したロゴがアップロードされているリポジトリです。
-
-## 言語 / Languages
-
-- [English](./README_EN.md)
-
 
 > [!WARNING]  
  ここにあるロゴはさわらつきが作成したロゴです。各サービス、団体が作成したものではありません。  

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,10 +1,8 @@
 # KawaiiLogos
 
+[日本語 README](./README.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
+
 Hello and good evening. This is the repository where the logos created by Sawaratsuki are uploaded.
-
-## Languages
-
-- [Japanese](./README.md)
 
 
 > [!WARNING]

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md)
+[日本語 README](./README.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md)
 
 Hello and good evening. This is the repository where the logos created by Sawaratsuki are uploaded.
 


### PR DESCRIPTION
Name of language is in original language except Indonesian because it was like this before, README is just kept as README, if anyone thinks this isn't straightforward for users of certain language please make a PR thanks :D 
No content changes have been made other than removing the unnecessary Language section.