### PR TITLE
Fix Issue Labeler settings

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,13 +1,13 @@
 policy:
-  - template: ["request.yml"]
+  - template: ["request.yml", "request_en.yml"]
     section:
       - id: ["logo-category"]
         block-list: []
         label:
           - name: "service"
-            keys: ["service"]
+            keys: ["service", "Service"]
           - name: "original"
-            keys: ["original"]
+            keys: ["original", "Original"]
           - name: "unknown"
             keys: ["None", "unknown"]
       - id: ["permission"]

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        template: [ request.yml ]
+        template: [request.yml, request_en.yml]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 概要
#107  のプルリクエストにおいて英語訳の[テンプレート](https://github.com/SAWARATSUKI/KawaiiLogos/blob/main/.github/ISSUE_TEMPLATE/request_en.yml)が追加されたため、Issue Labelerに対応させる。

## 関連話題
issueのラベルについて伝え忘れていたことがあったので[リンク](https://github.com/SAWARATSUKI/KawaiiLogos/pull/66#issuecomment-2106166172)しときます。