### PR TITLE
fix: spanish readme typos and add readme-es redirect link to all readme

### DIFF
--- a/README-ID.md
+++ b/README-ID.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md)
+[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md) | [README Español](/README-es.md)
 
 Hai semuanya. Repositori ini adalah tempat di mana logo-logo yang dibuat oleh Sawaratsuki diunggah.
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md)
+[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Español](/README-es.md)
 
 Bonjour et bonsoir. Ceci est le dépôt où les logos créés par Sawaratsuki sont téléchargés.
 

--- a/README-kr.md
+++ b/README-kr.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [README Français](/README-fr.md)
+[日本語 README](./README.md) | [English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [README Français](/README-fr.md) | [README Español](/README-es.md)
 
 안녕하세요. 이 리포지토리는 사와라츠키(さわらつき)가 제작한 로고를 업로드한 리포지토리입니다.
 

--- a/README-tr.md
+++ b/README-tr.md
@@ -1,6 +1,6 @@
 # KawaiiLogolar
 
-[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md)
+[日本語 README](./README.md) | [English README](/README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md) | [README Español](/README-es.md)
 
 Merhaba ve iyi akşamlar. Bu depo, Sawaratsuki tarafından oluşturulan logoların yüklendiği yerdir.
 

--- a/README-zhHans.md
+++ b/README-zhHans.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [English README](/README_EN.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md)
+[日本語 README](./README.md) | [English README](/README_EN.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md) | [README Español](/README-es.md)
 
 大家好！这个仓库是用于上传由 Sawaratsuki 创建的 Logo 的仓库。
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md)
+[English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md) | [README Español](/README-es.md)
 
 こんにちは、こんばんは。このリポジトリはさわらつきが作成したロゴがアップロードされているリポジトリです。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,6 @@
 # KawaiiLogos
 
-[日本語 README](./README.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md)
+[日本語 README](./README.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md) | [README Español](/README-es.md)
 
 Hello and good evening. This is the repository where the logos created by Sawaratsuki are uploaded.
 

--- a/README_es.md
+++ b/README_es.md
@@ -4,14 +4,13 @@ Hola y buenas noches. Este es el repositorio donde los logos creados por Sawarat
 
 [日本語 README](./README.md) | [English README](./README_EN.md) | [简体中文 README](/README-zhHans.md) | [Indonesian README](/README-ID.md) | [Türkçe README](/README-tr.md) | [한국어 README](/README-kr.md) | [README Français](/README-fr.md)
 
-
 > [!WARNING]
  Los logos que aquí están han sido creados por Sawaratsuki. No fueron creados por sus respectivas organizaciones o servicios.
  No todos los logos son usados de manera oficial.
  Por favor tenga cuidado de no tener una sobredosis de lo "kawaii".
 
 > [!IMPORTANT]
- Los contenidos de este repositorio no deben ser usados para IA o cualquier otra cosa que Sawaratsuki considere equivalente. 
+ Los contenidos de este repositorio no deben ser usados para IA o cualquier otra cosa que Sawaratsuki considere equivalente.
  Por favor tenga en cuenta esto.
 
 ## Licencia
@@ -24,13 +23,13 @@ Este repositorio esta licenciado bajo la siguiente licencia propietaria.
 
 "Official" aquí se refiere a la persona u organización que tiene los derechos del logo, no el nombre de cada logo o el mismo logo creado originalmente por Sawaratsuki.
 
-### Todos los terminos
+### Todos los términos
 
 - Eres libre de usar los logos solo para uso personal.
 Por ejemplo, la producción de stickers se considera uso personal.
   > [!ATENCIÓN]
     Cualquier trabajo creado usando estos logos no debe ser vendido.
-- El uso comercial de los logos está prohibido. 
+- El uso comercial de los logos está prohibido.
 Sin embargo, el uso comercial está permitido en los siguientes casos
   - Si estás usando el logo como el logo oficial del logo que quieres usar para propósitos comerciales, o si has obtenido permiso del logo oficial para todos los terminos de esta licencia.
   - Si estás autorizado a usar el logo siguiendo la "Licecia de cada logo" más abajo
@@ -59,14 +58,14 @@ Puedes usarlos en sitios web monetizados.
 
 Estos logos son solo para uso secundario.
 No te forzamos a usarlos como los oficiales.
-Nos gustaría expresar nuestra más sincera gratitud a quellos que han cerado los logos kawaii y nos han autorizado a usarlos.
+Nos gustaría expresar nuestra más sincera gratitud a aquellos que han creado los logos kawaii y nos han autorizado a usarlos.
 
 ## Sobre peticiones de logos
 
-- Por favor presenta un Issue. 
+- Por favor presenta un Issue.
 Si has recibido el permiso oficial para la creación del logo pedido, daremos prioridad en la creación de ese logo.
 - No añadiremos más logos que aquellos creados por Sawaratsuki en este repositorio.
-Por tanto, no vamos a hacer merge de ningun logo adicional a través de Pull Request u otros medios. 
+Por tanto, no vamos a hacer merge de ningun logo adicional a través de Pull Request u otros medios.
 
 ## Peticiones de eliminación de logos
 


### PR DESCRIPTION
# Pull Request

## Description

Fixed typos + spacing in the Spanish README and added a redirect link to readme-es in all README files.

## Related Issues

No related Issues

## Pictures (if applicable)

No pictures applicable for this fix.

## Checklist

- [x] I have tested the changes/updates before submitting this pull request.

## Additional Notes
No additional notes.